### PR TITLE
(#187) Fix installing multiple packages with force

### DIFF
--- a/chocolatey/plugins/modules/win_chocolatey.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey.ps1
@@ -209,7 +209,9 @@ if ($state -in @("downgrade", "latest", "upgrade", "present", "reinstalled")) {
     $missingPackages = [System.Collections.Generic.List[string]]@()
 
     if ($state -eq "present" -and $force) {
-        $missingPackages.Add($name)
+        foreach ($package in $name) {
+            $missingPackages.Add($package)
+        }
     }
     else {
         foreach ($package in $packageInfo.GetEnumerator()) {

--- a/chocolatey/tests/integration/targets/win_chocolatey/tasks/tests.yml
+++ b/chocolatey/tests/integration/targets/win_chocolatey/tasks/tests.yml
@@ -751,3 +751,17 @@
     that:
     - ignore_pinned_upgrade is changed
     - ignore_pinned_upgrade is not failed
+
+- name: force install multiple packages
+  win_chocolatey:
+    name:
+    - '{{ test_choco_package1 }}'
+    - '{{ test_choco_package2 }}'
+    state: present
+  register: force_install_multiple
+
+- name: assert force install multiple packages
+  assert:
+    that:
+    - force_install_multiple is changed
+    - force_install_multiple is not failed


### PR DESCRIPTION
## Description Of Changes

This PR ensures that lists of packages are still treated as lists when provided alongside the `Force` flag on `win_chocolatey`.

Additionally, tests have been added to cover the failure case that this change fixes.

## Motivation and Context

Currently, when using the force flag on the win_chocolatey command the list of packages is being added to the collection of missing packages as a single string. This results in the packages being passed to choco.exe bounded by quote character (e.g. `"package1 package2"`) and so this is being interpreted as a single (incorrect) package name.

## Testing

```yaml
---
- hosts: testvm
  gather_facts: true

  tasks:
  - name: Install list of software
    chocolatey.chocolatey.win_chocolatey:
      name:
        - 7zip
        - firefox
      state: present
    register: force_install_multiple

  - name: assert install multiple packages
    assert:
      that:
      - force_install_multiple is not changed
      - force_install_multiple is not failed

  - name: Force nstall list of software
    chocolatey.chocolatey.win_chocolatey:
      name:
        - 7zip
        - firefox
      state: present
      force: true
      ignore_checksums: true
    register: force_install_multiple

  - name: assert force install multiple packages
    assert:
      that:
      - force_install_multiple is changed
      - force_install_multiple is not failed
...
```

### Operating Systems Testing

N/A

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #187