### PR TITLE
(#185) Update ansible-core versions supported/tested

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It contains the following modules:
 
 ## Requirements
 
-- `ansible-core` >= 2.16, 2.17, 2.18
+- `ansible-core` >= 2.18, 2.19, 2.20
 - `python` >= 3.8
 
 ### Python Dependencies
@@ -108,7 +108,7 @@ Remove the Community Package Repository (as you have an internal repository; rec
 
 ## Testing
 
-This collection is tested against `ansible-core` versions >= **2.16, 2.17, 2.18**.
+This collection is tested against `ansible-core` versions >= **2.18, 2.19, 2.20**.
 
 Testing is primarily conducted on Ubuntu runners in Azure Pipelines at the latest OS version, with the collection being targeted at a Windows 10 Enterprise 21H2 client machine, using `ansible-test` to run the tests included in the collection.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ stages:
     pool:
       vmImage: ubuntu-latest
     variables:
-      Ansible.Package: "ansible-core~=2.18.0"
+      Ansible.Package: "ansible-core~=2.20.0"
 
     steps:
     - task: Bash@3
@@ -131,15 +131,15 @@ stages:
     strategy:
       maxParallel: 1
       matrix:
-        ansible217:
-          Ansible.Package: "ansible-core~=2.17.0"
-          Ansible.Version: "2.17"
         ansible218:
           Ansible.Package: "ansible-core~=2.18.0"
           Ansible.Version: "2.18"
         ansible219:
           Ansible.Package: "ansible-core~=2.19.0"
           Ansible.Version: "2.19"
+        ansible220:
+          Ansible.Package: "ansible-core~=2.20.0"
+          Ansible.Version: "2.20"
         ansible-latest:
           Ansible.Package: "ansible-core"
           Ansible.Version: "latest"
@@ -322,7 +322,7 @@ stages:
   - Test
   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
   variables:
-    Ansible.Package: 'ansible-core~=2.18.0'
+    Ansible.Package: 'ansible-core~=2.20.0'
 
   jobs:
   - job: Publish

--- a/chocolatey/meta/runtime.yml
+++ b/chocolatey/meta/runtime.yml
@@ -1,1 +1,1 @@
-requires_ansible: '>=2.16.0'
+requires_ansible: '>=2.18.0'


### PR DESCRIPTION
## Description Of Changes

- Set collection minimum ansible-core version to 2.18, the current lowest version that is still supported
- Update CI testing to test 2.18-2.20
- Build collection on 2.20 of ansible-core
- Update readme

## Motivation and Context

We need to keep in-step with Ansible's supported versions of ansible-core and ensure we're testing appropriately.

## Testing

Running tests in CI from the PR

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [x] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #185
